### PR TITLE
Strict Locking

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,9 @@ options:
     type: string
     default: ""
     description: "Raw configuration provide key=value comma seperated keys semicolon seperated shares"
+  smb-strict-locking:
+    type: string
+    default: "no"
+    description: "Set strict locking see smb.conf for details.
+           Well-behaved clients always ask for lock checks when it is important. So in the vast
+           majority of cases, strict locking = Auto or strict locking = no is acceptable."

--- a/lib/libsmb.py
+++ b/lib/libsmb.py
@@ -179,6 +179,12 @@ class SambaHelper:
                 for setting in share.split(","):
                     key, value = setting.split("=")
                     self.smb_config[share_name][key] = value
+        locking_config = "no"
+        if self.charm_config["smb-strict-locking"].lower() == "yes":
+            locking_config = "yes"
+        elif self.charm_config["smb-strict-locking"].lower() == "auto":
+            locking_config = "Auto"
+        self.smb_config["global"]["strict locking"] = locking_config
         for section in self.smb_config.keys():
             sections = ["global"]
             if self.charm_config["smb-shares"]:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,6 @@ description: |
 series:
   - xenial
   - bionic
-  - cosmic
 tags:
   - storage 
 subordinate: false

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -3,4 +3,5 @@ juju
 mock
 pytest
 pytest-asyncio
+pytest-timeout
 requests

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -10,11 +10,11 @@ juju_repository = os.getenv("JUJU_REPOSITORY", ".").rstrip("/")
 series = [
     "xenial",
     "bionic",
-    # pytest.param("disco", marks=pytest.mark.xfail(reason="canary")),
+    pytest.param("disco", marks=pytest.mark.xfail(reason="canary")),
 ]
 sources = [
     ("local", "{}/builds/samba-server".format(juju_repository)),
-    # ('jujucharms', 'cs:...'),
+    ('jujucharms', 'cs:~pirate-charmers/samba-server'),
 ]
 
 
@@ -35,25 +35,32 @@ async def app(model, series, source):
     return await model._wait_for_new("application", app_name)
 
 
-async def test_samba_deploy(model, series, source):
+@pytest.mark.deploy
+@pytest.mark.timeout(60)
+async def test_samba_deploy(model, series, source, request):
     # Starts a deploy for each series
     # Using subprocess b/c libjuju fails with JAAS
     # https://github.com/juju/python-libjuju/issues/221
     application_name = "samba-server-{}-{}".format(series, source[0])
-    subprocess.check_call(
-        [
-            "juju",
-            "deploy",
-            source[1],
-            "-m",
-            model.info.name,
-            "--series",
-            series,
-            application_name,
-        ]
-    )
+    cmd = [
+        "juju",
+        "deploy",
+        source[1],
+        "-m",
+        model.info.name,
+        "--series",
+        series,
+        application_name,
+    ]
+    if request.node.get_closest_marker("xfail"):
+        # If series is 'xfail' force install to allow testing against versions not in
+        # metadata.yaml
+        cmd.append("--force")
+    subprocess.check_call(cmd)
 
 
+@pytest.mark.deploy
+@pytest.mark.timeout(420)
 async def test_charm_upgrade(model, app):
     if app.name.endswith("local"):
         pytest.skip("No need to upgrade the local deploy")
@@ -73,6 +80,7 @@ async def test_charm_upgrade(model, app):
 
 
 # Tests
+@pytest.mark.timeout(420)
 async def test_samba_status(model, app):
     # Verifies status for all deployed series of the charm
     await model.block_until(lambda: app.status == "active")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -87,7 +87,7 @@ def mock_hookenv_config(monkeypatch):
 
     def mock_config():
         cfg = {}
-        yml = yaml.load(open('./config.yaml'))
+        yml = yaml.safe_load(open('./config.yaml'))
 
         # Load all defaults
         for key, value in yml['options'].items():

--- a/tests/unit/test_libsmb.py
+++ b/tests/unit/test_libsmb.py
@@ -43,6 +43,36 @@ class TestLibsmb:
             assert "[print$]" not in cfg
             assert "[global]" in cfg
 
+        # Test strict locking default
+        assert "strict locking" in smb.smb_config['global']
+        with open(smb.config_file, "r") as config:
+            cfg = config.read()
+            assert "strict locking = no" in cfg
+
+        # Test strict locking auto
+        smb.charm_config["smb-strict-locking"] = "Auto"
+        smb.update_config()
+        smb.save_config()
+        with open(smb.config_file, "r") as config:
+            cfg = config.read()
+            assert "strict locking = Auto" in cfg
+
+        # Test strict locking yes
+        smb.charm_config["smb-strict-locking"] = "Yes"
+        smb.update_config()
+        smb.save_config()
+        with open(smb.config_file, "r") as config:
+            cfg = config.read()
+            assert "strict locking = yes" in cfg
+
+        # Test strict locking invalid
+        smb.charm_config["smb-strict-locking"] = "i-dont-know"
+        smb.update_config()
+        smb.save_config()
+        with open(smb.config_file, "r") as config:
+            cfg = config.read()
+            assert "strict locking = no" in cfg
+
         # Test adding users
         smb.charm_config["smb-users"] = "ubuntu,utnubu"
         smb.update_config()
@@ -332,4 +362,4 @@ class TestLibsmb:
 
         # Check that service was restarted for each save
         assert mock_service.called_with(["reload", "smbd"])
-        assert mock_service.call_count == 30
+        assert mock_service.call_count == 36


### PR DESCRIPTION
This should be reviewed after PR #4 it's built on top of it.

This adds the global option Strict Locking = no to the config file. From the man page "Well-behaved clients always ask for lock checks when it is important. So in the vast majority of cases, strict locking = Auto or strict locking = no is acceptable."

The reason for this is I've found sharing network files (I verified on a cephfs, although NFS I believe will do the same thing) to 32-bit clients causes random failures to read when the server tries to add locking that the client didn't request. The specific use case is any Android based client (phones and Android TV for me) will get failure to read from the share.

I've set the value to 'no' by default but added a config option so that an advanced user that wants to configure it to something else can.

In this merge:
 * Strict locking added to config with option
 * Unit testing of the new value
 * Functional testing canary switched to disco
 * Upgrade testing from the charm store enabled, functional tests now test both install at this version and upgrade from the charmstore version.
 * Added timeouts to functional testing to prevent infinite hang if a deploy doesn't complete

Test pass except for:
 * Lint due to complexity of the config update function. That is true in the master branch today, and wasn't relevant to this change.
 * Upgrade of disco is XFail because upgrading doesn't allow the --force to change series to something not listed in metadata and disco isn't enabled just used as a canary. This is expected and disco does pass the other testing